### PR TITLE
Add missing "while" to do statement in keyCheck()

### DIFF
--- a/source.cpp
+++ b/source.cpp
@@ -156,7 +156,7 @@ void keyCheck() {
 		if (GetAsyncKeyState(VK_F3)) { 
 
 		}
-	}
+	} while (true); // have to add a while part to the do-while statement or else it won't compile
 }
 
 


### PR DESCRIPTION
You forgot a while statement to accompany the do-while statement you created in keyCheck(). If you don't add this, it won't compile.